### PR TITLE
Quote space field value in CQL query

### DIFF
--- a/confluence.py
+++ b/confluence.py
@@ -155,7 +155,7 @@ class Confluence():
         if ancestor_id:
             cql_args.append('ancestor={}'.format(ancestor_id))
         if space:
-            cql_args.append('space={}'.format(space))
+            cql_args.append('space={!r}'.format(space))
 
         cql = ' and '.join(cql_args)
 


### PR DESCRIPTION
The "space" field type allows to search by a space's key[1]. According
to [2] space keys can only contain alphanumeric characters and personal
spaces always use usernames as the space key. While not explicitly
mentioned, usernames are prefixed by '~'. In order to post to personal
spaces, the space field value in a CQL query must be quoted.

Bad query:

    'label=username_test and ancestor=12345678 and space=~username'
    => Expecting a value for operator '=' after field 'space' but got '~'

Good query:

    "label=username_test and ancestor=12345678 and space='~username'"

[1]: https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/#space
[2]: https://confluence.atlassian.com/doc/space-keys-829076188.html