### PR TITLE
Add --header command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker build -t markdown-to-confluence .
 usage: markdown-to-confluence.py [-h] [--git GIT] [--api_url API_URL]
                                  [--username USERNAME] [--password PASSWORD]
                                  [--space SPACE] [--ancestor_id ANCESTOR_ID]
-                                 [--dry-run]
+                                 [--header HEADER] [--dry-run]
                                  [posts [posts ...]]
 
 Converts and deploys a markdown post to Confluence
@@ -48,6 +48,9 @@ optional arguments:
   --ancestor_id ANCESTOR_ID
                         The Confluence ID of the parent page to place posts
                         under (default: env('CONFLUENCE_ANCESTOR_ID'))
+  --header HEADER       Extra header to include in the request when sending
+                        HTTP to a server. May be specified multiple times.
+                        (default: env('CONFLUENCE_HEADER_<NAME>'))
   --dry-run             Print requests that would be sent- don't actually make
                         requests against Confluence (note: we return empty
                         responses, so this might impact accuracy)

--- a/confluence.py
+++ b/confluence.py
@@ -28,6 +28,7 @@ class Confluence():
                  api_url=None,
                  username=None,
                  password=None,
+                 headers=None,
                  dry_run=False,
                  _client=None):
         """Creates a new Confluence API client.
@@ -36,7 +37,8 @@ class Confluence():
             api_url {str} -- The URL to the Confluence API root (e.g. https://wiki.example.com/api/rest/)
             username {str} -- The Confluence service account username
             password {str} -- The Confluence service account password
-            _dry_run {str} -- The Confluence service account password
+            headers {list(str)} -- The HTTP headers which will be set for all requests
+            dry_run {str} -- The Confluence service account password
         """
         # A common gotcha will be given a URL that doesn't end with a /, so we
         # can account for this
@@ -53,6 +55,12 @@ class Confluence():
 
         self._session = _client
         self._session.auth = (self.username, self.password)
+        for header in headers or []:
+            try:
+                name, value = header.split(':', 1)
+            except ValueError:
+                name, value = header, ''
+            self._session.headers[name] = value.lstrip()
 
     def _require_kwargs(self, kwargs):
         """Ensures that certain kwargs have been provided

--- a/markdown-to-confluence.py
+++ b/markdown-to-confluence.py
@@ -19,6 +19,25 @@ log = logging.getLogger(__name__)
 SUPPORTED_FORMATS = ['.md']
 
 
+def get_environ_headers(prefix):
+    """Returns a list of headers read from environment variables whose key
+    starts with prefix.
+
+    The header names are derived from the environment variable keys by
+    stripping the prefix. The header values are set to the environment
+    variable values.
+
+    Arguments:
+        prefix {str} -- The prefix of the environment variable keys which specify headers.
+    """
+    headers = []
+    for key, value in os.environ.items():
+        if key.startswith(prefix):
+            header_name = key[len(prefix):]
+            headers.append("{}:{}".format(header_name, value))
+    return headers
+
+
 def get_last_modified(repo):
     """Returns the paths to the last modified files in the provided Git repo
     
@@ -98,6 +117,15 @@ def parse_args():
         default=os.getenv('CONFLUENCE_GLOBAL_LABEL'),
         help=
         'The label to apply to every post for easier discovery in Confluence (default: env(\'CONFLUENCE_GLOBAL_LABEL\'))'
+    )
+    parser.add_argument(
+        '--header',
+        metavar='HEADER',
+        dest='headers',
+        action='append',
+        default=get_environ_headers('CONFLUENCE_HEADER_'),
+        help=
+        'Extra header to include in the request when sending HTTP to a server. May be specified multiple times. (default: env(\'CONFLUENCE_HEADER_<NAME>\'))'
     )
     parser.add_argument(
         '--dry-run',
@@ -205,6 +233,7 @@ def main():
     confluence = Confluence(api_url=args.api_url,
                             username=args.username,
                             password=args.password,
+                            headers=args.headers,
                             dry_run=args.dry_run)
 
     if args.posts:

--- a/test/test_confluence.py
+++ b/test/test_confluence.py
@@ -133,5 +133,38 @@ class TestConfluence(unittest.TestCase):
         self.assertEqual(got['userKey'], userKey)
 
 
+class TestConfluenceHeaders(unittest.TestCase):
+    def assert_headers(self, got, want):
+        for name, value in want.items():
+            self.assertEqual(got[name], value)
+
+    def testHeaders(self):
+        headers = ['Cookie: NAME=VALUE', 'X-CUSTOM-HEADER: VALUE']
+        want = {'Cookie': ' NAME=VALUE', 'X-CUSTOM-HEADER': ' VALUE'}
+
+        api = Confluence(api_url='https://wiki.example.com/rest/api',
+                         headers=headers)
+        self.assert_headers(api._session.headers, want)
+
+    def testHeadersDuplicates(self):
+        # HTTP headers are case insensitive. If multiple headers with the same
+        # name are passed, the last one should win.
+        headers = ['X-CUSTOM-HEADER: foo', 'X-Custom-Header: bar', 'x-custom-header: baz']
+        want = {'x-custom-header': ' baz'}
+
+        api = Confluence(api_url='https://wiki.example.com/rest/api',
+                         headers=headers)
+        self.assert_headers(api._session.headers, want)
+
+    def testHeadersNoValue(self):
+        # If no value is set, an empty string should be used.
+        headers = ['X-CUSTOM-HEADER-1:', 'X-CUSTOM-HEADER-2']
+        want = {'X-CUSTOM-HEADER-1': '', 'X-CUSTOM-HEADER-2': ''}
+
+        api = Confluence(api_url='https://wiki.example.com/rest/api',
+                         headers=headers)
+        self.assert_headers(api._session.headers, want)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The argument allows users to specify one or more additional headers which
will be set for all requests.

The use case which prompted this change is a confluence instance behind
an authentication proxy. Instead of adding support for individual types
of proxies, I opted to add a generic --header option.

Usage example:

```
python markdown-to-confluence.py --header 'Cookie: X-AUTH-TOKEN=123' test.md
```
or
```
export CONFLUENCE_HEADER_Cookie='X-AUTH-TOKEN=123'
python markdown-to-confluence.py test.md
```