### PR TITLE
Don't skip YAML boundary markers in markdown

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -21,7 +21,7 @@ def parse(post_path):
         for line in post.readlines():
             # Check if this is the ending tag
             if line.strip() == YAML_BOUNDARY:
-                if raw_yaml:
+                if in_yaml and raw_yaml:
                     in_yaml = False
                     continue
             if in_yaml:

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -1,7 +1,9 @@
+import os
 import unittest
+import tempfile
 import textwrap
 
-from convert import convtoconf, ConfluenceRenderer
+from convert import convtoconf, ConfluenceRenderer, parse
 
 
 class TestConvert(unittest.TestCase):
@@ -49,3 +51,75 @@ class TestConvert(unittest.TestCase):
         got = got.strip()
         self.assertEqual(got, want)
         self.assertEqual(renderer.has_toc, True)
+
+
+class TestConvertParse(unittest.TestCase):
+    have_yaml = textwrap.dedent(
+        '''\
+        authors:
+          - username1
+          - username2
+        title: Test
+        wiki:
+          share: true
+          space: ~username
+          ancestor_id: 12345678
+        '''
+    )
+
+    want_yaml = {
+        'authors': ['username1', 'username2'],
+        'title': 'Test',
+        'wiki': {'share': True, 'space': '~username', 'ancestor_id': 12345678},
+    }
+
+    have_markdown = textwrap.dedent(
+        '''\
+        # Heading
+
+        ```yaml
+        ---
+        content
+        ---
+        ```
+        '''
+    )
+
+    want_markdown = have_markdown.strip()
+
+    def setUp(self):
+        self.tempfile = tempfile.NamedTemporaryFile(delete=False)
+        self.post_path = self.tempfile.name
+        self.tempfile.close()
+
+    def tearDown(self):
+        os.remove(self.post_path)
+
+    def test_one_yaml_boundary(self):
+        post = '\n'.join((
+            self.have_yaml,
+            '---',
+            self.have_markdown,
+        ))
+
+        with open(self.post_path, 'w') as f:
+            f.write(post)
+
+        front_matter, markdown = parse(self.post_path)
+        self.assertEqual(front_matter, self.want_yaml)
+        self.assertEqual(markdown, self.want_markdown)
+
+    def test_two_yaml_boundaries(self):
+        post = '\n'.join((
+            '---',
+            self.have_yaml,
+            '---',
+            self.have_markdown,
+        ))
+
+        with open(self.post_path, 'w') as f:
+            f.write(post)
+
+        front_matter, markdown = parse(self.post_path)
+        self.assertEqual(front_matter, self.want_yaml)
+        self.assertEqual(markdown, self.want_markdown)


### PR DESCRIPTION
The parse() logic skipped all YAML_BOUNDARY markers. It was not possible
to use them in markdown, e.g. within yaml code blocks.