### PR TITLE
Adding .travis.yml to enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+install:
+  - pip install -r requirements.txt
+script:
+  - python -m unittest


### PR DESCRIPTION
This commit enables Travis CI for use in continuous testing as we make changes to the project.

If this works, we should see the builds pass in the updates below this message.